### PR TITLE
Fix windows issues

### DIFF
--- a/randomname/util.py
+++ b/randomname/util.py
@@ -107,9 +107,8 @@ def close_matches(name, cutoff=0.65):
     '''Find close matching wordlist names.'''
     # they entered a underspecified category
     name = doalias(name)
-    matches = [cat for cat in ALL_CATEGORIES if name == cat.split('/', 1)[1]]
-    all_sub_categories = [c.split('/', 1)[-1] for c in ALL_CATEGORIES]
-
+    matches = [cat for cat in ALL_CATEGORIES if name == cat.split(os.sep, 1)[1]]
+    all_sub_categories = [c.split(os.sep, 1)[-1] for c in ALL_CATEGORIES]
     if '/' in name:
         part0, part1 = name.split('/', 1)
         if not part0:
@@ -117,10 +116,12 @@ def close_matches(name, cutoff=0.65):
         # they spelled the first part correctly
         if part0 in WORD_CLASSES:
             _ms = _get_matches(part1, AVAILABLE[part0], cutoff=cutoff)
+            # TODO: This uses actual file names while the other ones uses names
             matches += [f for f in ('{}/{}'.format(part0, m) for m in _ms) if as_valid_path(f)]
         # they entered a misspelled category
         elif part1 in all_sub_categories:
             _ms = _get_matches(part0, [k for k in AVAILABLE if part1 in AVAILABLE[k]], cutoff=cutoff)
+            # TODO: This uses actual file names while the other ones uses names
             matches += [f for f in ('{}/{}'.format(m, part1) for m in _ms) if as_valid_path(f)]
         # they entered a misspelled category and misspelled group
         else:
@@ -188,7 +189,9 @@ def doalias(fname):
 
 def safepath(f):
     '''Make sure a path doesn't go up any directories.'''
-    return os.path.abspath('/' + f).lstrip('/')
+    name_parts = f.split("/")
+    name_parts = [part for part in name_parts if not part.startswith("..")]
+    return os.path.join(*name_parts)
 
 
 def as_valid_path(name, required=False):
@@ -202,7 +205,7 @@ def as_valid_path(name, required=False):
 
 def prefix(pre, xs):
     '''Prefix all items with a path prefix.'''
-    return [os.path.join(pre, x.lstrip('/')) for x in as_multiple(xs)]
+    return [f"{pre}/{x.lstrip('/')}" for x in as_multiple(xs)]
 
 
 def choose(items, n=None):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import randomname
 
 
@@ -15,3 +17,10 @@ def test_generate():
     assert name[1] in randomname.util.get_groups_list('a/music_theory')
     assert name[2] in randomname.util.get_groups_list('n/food')
     assert name[0] not in randomname.util.get_groups_list('n/food')
+
+def test_generated_names_are_valid_file_names(tmp_path: Path):
+    names = randomname.generate()
+
+    for name in names:
+        # does not raise
+        (Path(tmp_path) / name).touch()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -19,8 +19,8 @@ def test_generate():
     assert name[0] not in randomname.util.get_groups_list('n/food')
 
 def test_generated_names_are_valid_file_names(tmp_path: Path):
-    names = randomname.generate()
+    random_names = [randomname.generate() for _ in range(10)]
 
-    for name in names:
+    for name in random_names:
         # does not raise
         (Path(tmp_path) / name).touch()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import randomname
 
 
@@ -23,36 +25,56 @@ def test_load():
 
 def test_close_matches():
     # test underspecified
-    assert set(randomname.util.close_matches('music')) == {
-        'verbs/music',
-        'nouns/music_theory',
-        'adjectives/music_theory',
-        'nouns/music_production',
-        'verbs/music_production',
-        'nouns/music_instruments',
-    }
+    matches = randomname.util.close_matches('music')
+    assert {Path(m) for m in matches} == {
+            Path('verbs/music'),
+            Path('nouns/music_theory'),
+            Path('adjectives/music_theory'),
+            Path('nouns/music_production'),
+            Path('verbs/music_production'),
+            Path('nouns/music_instruments'),
+        }
+
     # test specific group
-    assert set(randomname.util.close_matches('n/music')) == {
-        'nouns/music_production', 'nouns/music_instruments', 'nouns/music_theory'}
-    assert set(randomname.util.close_matches('nouns/music')) == {
-        'nouns/music_production', 'nouns/music_instruments', 'nouns/music_theory'}
-    assert set(randomname.util.close_matches('v/music')) == {
-        'verbs/music', 'verbs/music_production'}
-    assert set(randomname.util.close_matches('a/music')) == {'adjectives/music_theory'}
+    for name in ['n/music', 'nouns/music']:
+        matches = randomname.util.close_matches(name)
+        assert {Path(m) for m in matches} == {
+            Path('nouns/music_production'),
+            Path('nouns/music_instruments'),
+            Path('nouns/music_theory')
+        }
+
+    matches = randomname.util.close_matches('v/music')
+    assert {Path(m) for m in matches} == {
+        Path('verbs/music'), Path('verbs/music_production')}
+
+    matches = randomname.util.close_matches('a/music')
+    assert {Path(m) for m in matches} == {Path('adjectives/music_theory')}
 
     # test fnmatch
     assert set(randomname.util.close_matches('a/*usic')) == set()
-    assert set(randomname.util.close_matches('a/*usic*')) == {'adjectives/music_theory'}
+
+    matches = randomname.util.close_matches('a/*usic*')
+    assert {Path(m) for m in matches} == {Path('adjectives/music_theory')}
 
     # test partials/misc
-    assert set(randomname.util.close_matches('tast')) == {'adjectives/taste'}
-    assert set(randomname.util.close_matches('tasty')) == {'adjectives/taste'}
-    assert set(randomname.util.close_matches('tasty', 0.4)) == {
-        'adjectives/taste', 'nouns/astronomy', 'nouns/metals'}
-    assert set(randomname.util.close_matches('phy')) == {
-        'adjectives/physics',
-        'nouns/physics',
-        'nouns/physics_waves',
-        'nouns/physics_units',
-        'nouns/physics_optics',
+    for name in ['tast', 'tasty']:
+        matches = randomname.util.close_matches(name)
+        assert {Path(m) for m in matches} == {
+            Path('adjectives/taste'),
+        }
+
+    matches = randomname.util.close_matches('tasty', 0.4)
+    assert {Path(m) for m in matches} == {
+        Path('adjectives/taste'),
+        Path('nouns/astronomy'),
+        Path('nouns/metals')}
+
+    matches = randomname.util.close_matches('phy')
+    assert {Path(m) for m in matches} == {
+        Path('adjectives/physics'),
+        Path('nouns/physics'),
+        Path('nouns/physics_waves'),
+        Path('nouns/physics_units'),
+        Path('nouns/physics_optics'),
     }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import randomname
 
 
@@ -25,56 +23,36 @@ def test_load():
 
 def test_close_matches():
     # test underspecified
-    matches = randomname.util.close_matches('music')
-    assert {Path(m) for m in matches} == {
-            Path('verbs/music'),
-            Path('nouns/music_theory'),
-            Path('adjectives/music_theory'),
-            Path('nouns/music_production'),
-            Path('verbs/music_production'),
-            Path('nouns/music_instruments'),
-        }
-
+    assert set(randomname.util.close_matches('music')) == {
+        'verbs/music',
+        'nouns/music_theory',
+        'adjectives/music_theory',
+        'nouns/music_production',
+        'verbs/music_production',
+        'nouns/music_instruments',
+    }
     # test specific group
-    for name in ['n/music', 'nouns/music']:
-        matches = randomname.util.close_matches(name)
-        assert {Path(m) for m in matches} == {
-            Path('nouns/music_production'),
-            Path('nouns/music_instruments'),
-            Path('nouns/music_theory')
-        }
-
-    matches = randomname.util.close_matches('v/music')
-    assert {Path(m) for m in matches} == {
-        Path('verbs/music'), Path('verbs/music_production')}
-
-    matches = randomname.util.close_matches('a/music')
-    assert {Path(m) for m in matches} == {Path('adjectives/music_theory')}
+    assert set(randomname.util.close_matches('n/music')) == {
+        'nouns/music_production', 'nouns/music_instruments', 'nouns/music_theory'}
+    assert set(randomname.util.close_matches('nouns/music')) == {
+        'nouns/music_production', 'nouns/music_instruments', 'nouns/music_theory'}
+    assert set(randomname.util.close_matches('v/music')) == {
+        'verbs/music', 'verbs/music_production'}
+    assert set(randomname.util.close_matches('a/music')) == {'adjectives/music_theory'}
 
     # test fnmatch
     assert set(randomname.util.close_matches('a/*usic')) == set()
-
-    matches = randomname.util.close_matches('a/*usic*')
-    assert {Path(m) for m in matches} == {Path('adjectives/music_theory')}
+    assert set(randomname.util.close_matches('a/*usic*')) == {'adjectives/music_theory'}
 
     # test partials/misc
-    for name in ['tast', 'tasty']:
-        matches = randomname.util.close_matches(name)
-        assert {Path(m) for m in matches} == {
-            Path('adjectives/taste'),
-        }
-
-    matches = randomname.util.close_matches('tasty', 0.4)
-    assert {Path(m) for m in matches} == {
-        Path('adjectives/taste'),
-        Path('nouns/astronomy'),
-        Path('nouns/metals')}
-
-    matches = randomname.util.close_matches('phy')
-    assert {Path(m) for m in matches} == {
-        Path('adjectives/physics'),
-        Path('nouns/physics'),
-        Path('nouns/physics_waves'),
-        Path('nouns/physics_units'),
-        Path('nouns/physics_optics'),
+    assert set(randomname.util.close_matches('tast')) == {'adjectives/taste'}
+    assert set(randomname.util.close_matches('tasty')) == {'adjectives/taste'}
+    assert set(randomname.util.close_matches('tasty', 0.4)) == {
+        'adjectives/taste', 'nouns/astronomy', 'nouns/metals'}
+    assert set(randomname.util.close_matches('phy')) == {
+        'adjectives/physics',
+        'nouns/physics',
+        'nouns/physics_waves',
+        'nouns/physics_units',
+        'nouns/physics_optics',
     }


### PR DESCRIPTION
 **Proposed Changes**
* fix https://github.com/beasteers/randomname/issues/1
* make tests Windows compatible by comparing expected paths instead of raw strings
* split paths using `os.sep` instead of `/`

**Reasoning**
I tried to keep the interface for users on all OSes the same which means that they would always use `/` instead of `/` on Unix based systems and `\` on Windows. The reasoning behind that is that users don't know that the library matches this to filenames in the background and hence different library behavior based on OS would be very weird.