### PR TITLE
Fix package_data to include nested directories

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import setuptools
+from pathlib import Path
 
 USERNAME = 'beasteers'
 NAME = 'randomname'
@@ -13,7 +14,7 @@ setuptools.setup(
     author_email='bea.steers@gmail.com',
     url='https://github.com/{}/{}'.format(USERNAME, NAME),
     packages=setuptools.find_packages(),
-    package_data={NAME: ['wordlists/**/*.txt']},
+    package_data={NAME: [str(path.relative_to(NAME)) for path in Path(f"{NAME}/wordlists").rglob("*.txt")]},
     entry_points={'console_scripts': ['{name}={name}:main'.format(name=NAME)]},
     install_requires=['fire'],
     tests_require=['pytest'],


### PR DESCRIPTION
Glob matching is not recursive, so current `package_data` does not include `wordlists/names/**`, which causes errors when trying to generate names. `rglob` from `pathlib.Path` is recursive.